### PR TITLE
CFITSIOError subtypes Exception

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CFITSIO"
 uuid = "3b1b4be9-1499-4b22-8d78-7db3344d1961"
 authors = ["Miles Lucas <mdlucas@hawaii.edu> and contributors"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 CFITSIO_jll = "b3e40c51-02ae-5482-8a39-3ace5868dcf4"

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -158,7 +158,7 @@ function fits_assert_open(f::FITSFile)
     end
 end
 
-struct CFITSIOError{T}
+struct CFITSIOError{T} <: Exception
     filename :: T
     errcode :: Cint
     errmsgshort :: String

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,6 +165,8 @@ end
                 f = fits_create_file("!$filename")
                 fits_close_file(f)
             catch e
+                @test e isa CFITSIO.CFITSIOError
+                @test e isa Exception # bugfix test as CFITSIOError didn't subtype Exception in #3
                 io = IOBuffer()
                 Base.showerror(io, e)
                 errstr = String(take!(io))


### PR DESCRIPTION
The definition of `CFITSIOError` in #3 didn't make it a subtype of `Exception`. This PR fixes this and helps fix downstream test failures in `FITSIO`