### PR TITLE
read/write images without temporary allocations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,13 @@ version = "1.2.0"
 CFITSIO_jll = "b3e40c51-02ae-5482-8a39-3ace5868dcf4"
 
 [compat]
-BenchmarkTools = "1"
+Aqua = "0.5"
 CFITSIO_jll = "3.47"
 julia = "1.3"
 
 [extras]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BenchmarkTools", "Test"]
+test = ["Aqua", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,11 +7,13 @@ version = "1.2.0"
 CFITSIO_jll = "b3e40c51-02ae-5482-8a39-3ace5868dcf4"
 
 [compat]
+BenchmarkTools = "1"
 CFITSIO_jll = "3.47"
 julia = "1.3"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["BenchmarkTools", "Test"]

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1780,6 +1780,22 @@ fits_get_coltype
         naxes
     end
 
+    function fits_get_img_size(f::FITSFile, ::Val{N}) where {N}
+        naxes = Ref(ntuple(_ -> zero($T), Val(N)))
+        status = Ref{Cint}(0)
+        ccall(
+            ($ffgisz, libcfitsio),
+            Cint,
+            (Ptr{Cvoid}, Cint, Ptr{NTuple{N,$T}}, Ref{Cint}),
+            f.ptr,
+            N,
+            naxes,
+            status,
+        )
+        fits_assert_ok(status[])
+        naxes[]
+    end
+
     function fits_get_num_rows(f::FITSFile)
         fits_assert_open(f)
         result = Ref{$T}(0)

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -230,6 +230,7 @@ fits_get_version() = ccall((:ffvers, libcfitsio), Cfloat, (Ref{Cfloat},), 0.0)
 # -----------------------------------------------------------------------------
 # Utility function
 
+zerost(::Type{T}, n) where {T} = ntuple(_ -> zero(T), n)
 onest(::Type{T}, n) where {T} = ntuple(_ -> one(T), n)
 
 # -----------------------------------------------------------------------------
@@ -1905,7 +1906,7 @@ fits_get_coltype
     end
 
     function fits_get_img_size(f::FITSFile, ::Val{N}) where {N}
-        naxes = Ref(ntuple(_ -> zero($T), Val(N)))
+        naxes = Ref(zerost($T, N))
         status = Ref{Cint}(0)
         ccall(
             ($ffgisz, libcfitsio),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using CFITSIO
 using Test
+using BenchmarkTools
 
 function tempfitsfile(fn)
     mktempdir() do dir
@@ -497,4 +498,18 @@ end
             @test b == a
         end
     end
+
+    @testset "size" begin
+        filename = tempname()
+        f = fits_clobber_file(filename)
+        a = ones(2,2)
+        fits_create_img(f, eltype(a), [size(a)...])
+        fits_write_pix(f, a)
+        close(f)
+        f = fits_open_file(filename, 0)
+        @test fits_get_img_size(f, Val(2)) == (2,2)
+        @test (BenchmarkTools.@ballocated fits_get_img_size($f, Val(2))) == 0
+        close(f)
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -505,24 +505,16 @@ end
             f = fits_clobber_file(filename)
             a = ones(2,2)
             b = similar(a); c = similar(a);
-            fits_create_img(f, eltype(a), size(a))
 
             @testset "create" begin
-                # create a different temp file so that the tests for read/write aren't
-                # slowed down by the large number of temporary images created
-                filename2 = tempname()
-                try
-                    g = fits_clobber_file(filename)
-                    @test (BenchmarkTools.@ballocated fits_create_img($g, eltype($a), size($a)) evals=3) == 0
-                    fits_write_pix(g, a)
-                    fits_read_pix(g, b)
-                    fits_create_img(g, eltype(a), [size(a)...])
-                    fits_write_pix(g, a)
-                    fits_read_pix(g, c)
-                    @test b == c
-                finally
-                    rm(filename2, force = true)
-                end
+                @test (BenchmarkTools.@ballocated fits_create_img($f, eltype($a), size($a)) evals=3) == 0
+                fits_create_img(f, eltype(a), size(a))
+                fits_write_pix(f, a)
+                fits_read_pix(f, b)
+                fits_create_img(f, eltype(a), [size(a)...])
+                fits_write_pix(f, a)
+                fits_read_pix(f, c)
+                @test b == c
             end
             @testset "write" begin
                 fits_write_pix(f, [1,1], length(a), a)


### PR DESCRIPTION
Add a method to `fits_get_img_size` to avoid intermediate allocations.

On master

setup code
```julia
julia> filename = tempname();

julia> f = fits_clobber_file(filename);

julia> a = ones(2,2);

julia> fits_create_img(f, eltype(a), [size(a)...])

julia> fits_write_pix(f, a)

julia> close(f)
```

The default method to read the image size (which still exists):
```julia
julia> f = fits_open_file(filename, 0);

julia> @btime fits_get_img_size($f)
  78.012 ns (1 allocation: 96 bytes)
2-element Vector{Int64}:
 2
 2
```

New method introduced in this PR:
```julia
julia> @btime fits_get_img_size($f, Val(2))
  25.895 ns (0 allocations: 0 bytes)
(2, 2)
```

The new method returns a `Tuple` instead of a `Vector`, and doesn't allocate. The second argument is the `ndims` of the image, wrapped in a `Val`. Often this is known to the caller at compile time. 

~~I've also added `BenchmarkTools` as a test dependency to check that this is allocation-free. The default `@allocated` macro was not very reliable for this.~~

I've added `Aqua.jl` as a test dependency to test project quality.