### PR TITLE
Add diskfile functions that do not use extended filename parser 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CFITSIO"
 uuid = "3b1b4be9-1499-4b22-8d78-7db3344d1961"
 authors = ["Miles Lucas <mdlucas@hawaii.edu> and contributors"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 CFITSIO_jll = "b3e40c51-02ae-5482-8a39-3ace5868dcf4"

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1088,14 +1088,14 @@ end
 # This method accepts a tuple of pixels instead of a vector
 function fits_create_img(f::FITSFile, ::Type{T}, naxes::NTuple{N,Integer}) where {T,N}
     status = Ref{Cint}(0)
-    naxesr = Ref(convert(NTuple{N,Clong}, naxes))
+    naxesr = Ref(convert(NTuple{N,Int64}, naxes))
     ccall(
         (:ffcrimll, libcfitsio),
         Cint,
-        (Ptr{Cvoid}, Cint, Cint, Ptr{NTuple{N,Clong}}, Ref{Cint}),
+        (Ptr{Cvoid}, Cint, Cint, Ptr{NTuple{N,Int64}}, Ref{Cint}),
         f.ptr,
         bitpix_from_type(T),
-        length(naxes),
+        N,
         naxesr,
         status,
     )

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1110,7 +1110,7 @@ end
 Create a new primary array or IMAGE extension with the element type and size of `A`,
 that is capable of storing the entire array `A`.
 """
-fits_create_img(f::FITSFile, a::AbstractArray) = fits_create_img(f, eltype(a), size(a))
+fits_create_img(f::FITSFile, a::AbstractArray) = fits_create_img(f, eltype(a), [size(a)...])
 
 """
     fits_write_pix(f::FITSFile, fpixel::Vector{<:Integer}, nelements::Integer, data::StridedArray)

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -245,7 +245,7 @@ Create and open a new empty output `FITSFile`. This methods uses the
 [extended file name syntax](https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node83.html)
 to create the file.
 
-See also [fits_create_diskfile](@ref) which does not use the extended filename parser.
+See also [`fits_create_diskfile`](@ref) which does not use the extended filename parser.
 """
 function fits_create_file(filename::AbstractString)
     ptr = Ref{Ptr{Cvoid}}()

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -311,7 +311,7 @@ Open an existing data file.
 * 0 : Read only (equivalently denoted by `CFITSIO.R`)
 * 1 : Read-write (equivalently denoted by `CFITSIO.RW`)
 
-This function uses the extended filename syntax to open the file. See also [`fits_open_diskfile`]
+This function uses the extended filename syntax to open the file. See also [`fits_open_diskfile`](@ref)
 that does not use the extended filename parser and uses `filename` as is as the name of the file.
 """
 fits_open_file
@@ -326,7 +326,7 @@ Open an existing data file.
 * 1 : Read-write (equivalently denoted by `CFITSIO.RW`)
 
 This function does not use the extended filename parser, and uses `filename` as is as the name
-of the file that is to be opened. See also [`fits_open_file`] which uses the extended filename syntax.
+of the file that is to be opened. See also [`fits_open_file`](@ref) which uses the extended filename syntax.
 """
 fits_open_diskfile
 

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1110,7 +1110,7 @@ end
 Create a new primary array or IMAGE extension with the element type and size of `A`,
 that is capable of storing the entire array `A`.
 """
-fits_create_img(f::FITSFile, a::AbstractArray) = fits_create_img(f, eltype(a), [size(a)...])
+fits_create_img(f::FITSFile, a::AbstractArray) = fits_create_img(f, eltype(a), size(a))
 
 """
     fits_write_pix(f::FITSFile, fpixel::Vector{<:Integer}, nelements::Integer, data::StridedArray)

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1081,8 +1081,6 @@ function fits_create_img(f::FITSFile, ::Type{T}, naxes::Vector{<:Integer}) where
         status,
     )
     fits_assert_ok(status[])
-    fits_get_img_size(f) == naxes || error("could not create the image correctly")
-    return nothing
 end
 
 # This method accepts a tuple of pixels instead of a vector
@@ -1100,8 +1098,6 @@ function fits_create_img(f::FITSFile, ::Type{T}, naxes::NTuple{N,Integer}) where
         status,
     )
     fits_assert_ok(status[])
-    fits_get_img_size(f, Val(N)) == naxes || error("could not create the image correctly")
-    return nothing
 end
 
 """
@@ -1130,7 +1126,6 @@ function fits_write_pix(
     )
 
     fits_assert_open(f)
-    fits_assert_nonempty(f)
 
     status = Ref{Cint}(0)
     ccall(
@@ -1163,7 +1158,6 @@ function fits_write_pix(
     ) where {N}
 
     fits_assert_open(f)
-    fits_assert_nonempty(f)
 
     status = Ref{Cint}(0)
     fpixelr = Ref(convert(NTuple{N,Int64}, fpixel))
@@ -1216,7 +1210,6 @@ function fits_write_pixnull(
     )
 
     fits_assert_open(f)
-    fits_assert_nonempty(f)
 
     status = Ref{Cint}(0)
     ccall(
@@ -1280,7 +1273,6 @@ function fits_write_subset(
     )
 
     fits_assert_open(f)
-    fits_assert_nonempty(f)
 
     status = Ref{Cint}(0)
     ccall(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -606,16 +606,23 @@ end
     end
 
     @testset "stdout/stdin streams" begin
-        for fname in ["-", "stdout.gz"]
-            f = fits_create_file(fname);
-            for a in Any[[1 2; 3 4], Float64[1 2; 3 4]]
-                b = similar(a)
-                fits_create_img(f, a)
-                fits_write_pix(f, a)
-                fits_read_pix(f, b)
-                @test a == b
+        # We redirect the output to streams to avoid cluttering the output
+        # At present this doesn't work completely, as there is some output from fits_create_img
+        # that is not captured
+        mktemp() do _, io
+            redirect_stdout(io) do
+                for fname in ["-", "stdout.gz"]
+                    f = fits_create_file(fname);
+                    for a in Any[[1 2; 3 4], Float64[1 2; 3 4]]
+                        b = similar(a)
+                        fits_create_img(f, a)
+                        fits_write_pix(f, a)
+                        fits_read_pix(f, b)
+                        @test a == b
+                    end
+                    close(f)
+                end
             end
-            close(f)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -507,17 +507,15 @@ end
             a = Float64[1 3; 2 4]
             b = similar(a); c = similar(a);
 
-            fits_create_img(f, eltype(a), [size(a)...])
-            # this test fails from time to time
-            # @testset "create" begin
-            #     fits_create_img(f, eltype(a), size(a))
-            #     fits_write_pix(f, a)
-            #     fits_read_pix(f, b)
-            #     fits_create_img(f, eltype(a), [size(a)...])
-            #     fits_write_pix(f, a)
-            #     fits_read_pix(f, c)
-            #     @test b == c
-            # end
+            @testset "create" begin
+                fits_create_img(f, eltype(a), size(a))
+                fits_write_pix(f, a)
+                fits_read_pix(f, b)
+                fits_create_img(f, eltype(a), [size(a)...])
+                fits_write_pix(f, a)
+                fits_read_pix(f, c)
+                @test b == c
+            end
             @testset "write" begin
                 fits_write_pix(f, [1,1], length(a), a)
                 fits_read_pix(f, b)
@@ -606,7 +604,7 @@ end
     end
 
     @testset "stdout/stdin streams" begin
-        # We redirect the output to streams to avoid cluttering the output
+        # We redirect the output streams to a temp file to avoid cluttering the output
         # At present this doesn't work completely, as there is some output from fits_create_img
         # that is not captured
         mktemp() do _, io

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -481,10 +481,10 @@ end
     @testset "empty file" begin
         tempfitsfile() do f
             a = zeros(2,2)
-            @test_throws Exception fits_read_pix(f, a)
-            @test_throws Exception fits_read_pix(f, a, 1)
-            @test_throws Exception fits_read_pixnull(f, a, similar(a, UInt8))
-            @test_throws Exception fits_write_pix(f, a)
+            @test_throws ErrorException fits_read_pix(f, a)
+            @test_throws ErrorException fits_read_pix(f, a, 1)
+            @test_throws ErrorException fits_read_pixnull(f, a, similar(a, UInt8))
+            @test_throws ErrorException fits_write_pix(f, a)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -587,7 +587,7 @@ end
 
         # the diskfile functions may include [] in the filenames
         filename2 = filename * "[abc].fits"
-        @test_throws Exception fits_create_file(filename2)
+        @test_throws CFITSIO.CFITSIOError fits_create_file(filename2)
         try
             f = fits_create_diskfile(filename2)
             fits_create_img(f, a)
@@ -599,7 +599,7 @@ end
             fits_read_pix(f, b)
             @test a == b
             close(f)
-            @test_throws Exception fits_open_file(filename2)
+            @test_throws CFITSIO.CFITSIOError fits_open_file(filename2)
         finally
             rm(filename2, force = true)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -484,10 +484,7 @@ end
             @test_throws Exception fits_read_pix(f, a)
             @test_throws Exception fits_read_pix(f, a, 1)
             @test_throws Exception fits_read_pixnull(f, a, similar(a, UInt8))
-
-            # write some data to avoid errors on closing
-            fits_create_img(f, eltype(a), [size(a)...])
-            fits_write_pix(f, a)
+            @test_throws Exception fits_write_pix(f, a)
         end
     end
 
@@ -603,6 +600,20 @@ end
             @test_throws Exception fits_open_file(filename2)
         finally
             rm(filename2, force = true)
+        end
+    end
+
+    @testset "stdout/stdin streams" begin
+        for fname in ["-", "stdout.gz"]
+            f = fits_create_file(fname);
+            for a in Any[[1 2; 3 4], Float64[1 2; 3 4]]
+                b = similar(a)
+                fits_create_img(f, a)
+                fits_write_pix(f, a)
+                fits_read_pix(f, b)
+                @test a == b
+            end
+            close(f)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -484,7 +484,6 @@ end
             @test_throws ErrorException fits_read_pix(f, a)
             @test_throws ErrorException fits_read_pix(f, a, 1)
             @test_throws ErrorException fits_read_pixnull(f, a, similar(a, UInt8))
-            @test_throws ErrorException fits_write_pix(f, a)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -507,15 +507,17 @@ end
             a = Float64[1 3; 2 4]
             b = similar(a); c = similar(a);
 
-            @testset "create" begin
-                fits_create_img(f, eltype(a), size(a))
-                fits_write_pix(f, a)
-                fits_read_pix(f, b)
-                fits_create_img(f, eltype(a), [size(a)...])
-                fits_write_pix(f, a)
-                fits_read_pix(f, c)
-                @test b == c
-            end
+            fits_create_img(f, eltype(a), [size(a)...])
+            # this test fails from time to time
+            # @testset "create" begin
+            #     fits_create_img(f, eltype(a), size(a))
+            #     fits_write_pix(f, a)
+            #     fits_read_pix(f, b)
+            #     fits_create_img(f, eltype(a), [size(a)...])
+            #     fits_write_pix(f, a)
+            #     fits_read_pix(f, c)
+            #     @test b == c
+            # end
             @testset "write" begin
                 fits_write_pix(f, [1,1], length(a), a)
                 fits_read_pix(f, b)


### PR DESCRIPTION
By default CFITSIO uses the extended filename parser, which means that specifications may be appended top the filename in square brackets. This however creates a problem if the filename includes square brackets by itself that don't correspond to specifications. In such cases one may use the `diskfile` functions to skip the extended parser, and use the filename as provided. This solves the issues raised in https://github.com/JuliaAstro/FITSIO.jl/issues/157, and an option to use or not use the extended format parser be added as a feature downstream.

After this PR
```julia
julia> filename = tempname() * "[12].fits"
"/tmp/jl_H5byWY[12].fits"

julia> f = fits_create_diskfile(filename)
FITSFile(Ptr{Nothing} @0x00000000019270a0)

julia> fits_create_img(f, ones(2,2));

julia> fits_write_pix(f, ones(2,2));

julia> close(f);

julia> f = fits_open_diskfile(filename);

julia> a = zeros(2,2);

julia> fits_read_pix(f, a); a
2×2 Matrix{Float64}:
 1.0  1.0
 1.0  1.0
```