### PR TITLE
Automatically remove temporary files in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,12 +8,8 @@ function tempfitsfile(fn)
         fitsfile = fits_clobber_file(filename)
         fn(fitsfile)
 
-        # Write arbitrary data to file to avoid errors on closing it
         if fitsfile.ptr != C_NULL
-            temp = ones(1)
-            fits_create_img(fitsfile, temp)
-            fits_write_pix(fitsfile, temp)
-            close(fitsfile)
+            fits_delete_file(fitsfile)
         end
     end
 end
@@ -311,8 +307,7 @@ end
     end
 
     @testset "error message" begin
-        mktempdir() do dir
-            filename = joinpath(dir, "temp.fits")
+        mktemp() do filename, _
             try
                 f = fits_clobber_file(filename)
                 fits_close_file(f)
@@ -405,12 +400,7 @@ end
                 close(f2)
 
                 @test_throws Exception fits_copy_image_section(f, f2, "1:2")
-
-                f2 = fits_clobber_file(fname2)
-                fits_create_img(f2, eltype(a), [size(a)...])
-                fits_write_pix(f2, a)
                 @test_throws Exception fits_copy_image_section(f2, f, "1:2")
-                close(f2)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,7 +63,7 @@ function writehealpix(filename, pixels, nside, ordering, coordsys)
         tform = "1D"
     end
 
-    file = fits_create_file("!"*filename)
+    file = fits_clobber_file(filename)
     try
         fits_create_img(file, Int16, Int[])
         fits_write_date(file)
@@ -139,8 +139,6 @@ end
 
             f = fits_open_file(filename, CFITSIO.RW)
             @test fits_file_mode(f) == 1 == Int(CFITSIO.RW)
-            close(f)
-
             close(f)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -392,8 +392,7 @@ end
 
             @test_throws Exception fits_create_img(f, Int64, [2,3])
 
-            mktemp() do fname2, _
-                f2 = fits_clobber_file(fname2)
+            tempfitsfile() do f2
                 fits_create_img(f2, eltype(a), [size(a)...])
                 fits_write_pix(f2, a)
                 close(f2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,7 +306,8 @@ end
     end
 
     @testset "error message" begin
-        mktemp() do filename, _
+        mktempdir() do dir
+            filename = joinpath(dir, "temp.fits")
             try
                 f = fits_clobber_file(filename)
                 fits_close_file(f)
@@ -318,6 +319,8 @@ end
                 errstr = String(take!(io))
                 @test occursin(r"Error code"i, errstr)
                 @test occursin(r"Error message"i, errstr)
+            finally
+                rm(filename, force=true)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -525,8 +525,7 @@ end
     end
 
     @testset "tuples vs vectors" begin
-        mktemp() do filename, _
-            f = fits_clobber_file(filename)
+        tempfitsfile() do f
             a = Float64[1 3; 2 4]
             b = similar(a); c = similar(a);
 
@@ -587,7 +586,6 @@ end
                 @test @views b[:,1] == b[:,2]
                 @test b[2,1] == b[2,2] == 4
             end
-            close(f)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,14 +181,15 @@ end
 
 
     # test reading/writing Healpix maps as FITS binary tables using the Libcfitsio interface
-    for T in (Float32, Float64)
-        nside = 4
-        npix = 12*nside*nside
-        pixels = rand(T, npix)
-        ordering = "NESTED"
-        coordsys = "G"
+    mktempdir() do dir
+        filename = joinpath(dir, "temp.fits")
+        for T in (Float32, Float64)
+            nside = 4
+            npix = 12*nside*nside
+            pixels = rand(T, npix)
+            ordering = "NESTED"
+            coordsys = "G"
 
-        mktemp() do filename, _
             writehealpix(filename, pixels, nside, ordering, coordsys)
             @test readhealpix(filename) == (pixels, nside, ordering, coordsys)
         end


### PR DESCRIPTION
This PR changes various uses of the `try..finally` pattern in tests to `mktemp`, so that temporary files are automatically removed