### PR TITLE
Bugfix in closing empty files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CFITSIO"
 uuid = "3b1b4be9-1499-4b22-8d78-7db3344d1961"
 authors = ["Miles Lucas <mdlucas@hawaii.edu> and contributors"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 CFITSIO_jll = "b3e40c51-02ae-5482-8a39-3ace5868dcf4"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,10 @@ function tempfitsfile(fn)
         fn(fitsfile)
 
         if fitsfile.ptr != C_NULL
+            # write some data to file to avoid errors on closing
+            data = ones(1)
+            fits_create_img(fitsfile, data)
+            fits_write_pix(fitsfile, data)
             fits_delete_file(fitsfile)
         end
     end


### PR DESCRIPTION
Evidently `fits_delete_file` does not ignore errors on closing empty files, as there is a CI failure on master. This PR should fix this.