### PR TITLE
Add doc entries for diskfile functions

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ CFITSIO = "3b1b4be9-1499-4b22-8d78-7db3344d1961"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -83,8 +83,10 @@ cfitsio_typecode
 
 ```@docs
 fits_create_file
+fits_create_diskfile
 fits_clobber_file
 fits_open_file
+fits_open_diskfile
 fits_open_table
 fits_open_image
 fits_open_data


### PR DESCRIPTION
Add doc entries for `fits_create_diskfile` and `fits_open_diskfile` which should resolve links in docs.