### PR TITLE
Insert a new primary HDU

### DIFF
--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1129,23 +1129,27 @@ fits_create_img(f::FITSFile, a::AbstractArray) = fits_create_img(f, eltype(a), s
 
 """
     fits_insert_img(f::FITSFile, T::Type,
-                    naxes::Union{Vector{<:Integer}, Tuple{Vararg{Integer}}}; prependprimary::Bool = false)
+                    naxes::Union{Vector{<:Integer}, Tuple{Vararg{Integer}}}; prepend_primary::Bool = false)
 
-Insert a new image extension immediately following the current HDU, or insert a new Primary Array
-at the beginning of the file. A new primary image may be inserted by calling `fits_insert_img` with
-`prependprimary` set to `true` after moving to the existing primary HDU, in which case the existing
-primary HDU is converted to an image extension.
+Insert a new image extension immediately following the current HDU (CHDU), or insert a new primary array
+at the beginning of the file.
+
+A new primary array may be inserted at the beginning of the FITS file by calling `fits_insert_img` with
+`prepend_primary` set to `true`. In this case, the existing primary HDU is converted to an image extension,
+and the new primary array will become the CHDU.
+
 The inserted array has an eltype `T` and size `naxes`.
 
-    fits_insert_img(f::FITSFile, a::AbstractArray{<:Real}; prependprimary::Bool = false)
+    fits_insert_img(f::FITSFile, a::AbstractArray{<:Real}; prepend_primary::Bool = false)
 
 Insert a new image HDU with an element type of `eltype(a)` and a size of `size(a)` that is capable
-of storing the array `a`. The flag `prependprimary` may be specified to insert a new primary image.
+of storing the array `a`. The flag `prepend_primary` may be specified to insert a new primary array at the
+beginning of the FITS file.
 """
-function fits_insert_img(f::FITSFile, T::Type, naxes::Vector{<:Integer}; prependprimary::Bool = false)
+function fits_insert_img(f::FITSFile, T::Type, naxes::Vector{<:Integer}; prepend_primary::Bool = false)
     fits_assert_open(f)
 
-    status = Ref{Cint}(prependprimary ? PREPEND_PRIMARY : 0)
+    status = Ref{Cint}(prepend_primary ? PREPEND_PRIMARY : 0)
     ccall(
         (:ffiimgll, libcfitsio),
         Cint,
@@ -1165,10 +1169,10 @@ function fits_insert_img(f::FITSFile, T::Type, naxes::Vector{<:Integer}; prepend
     fits_assert_ok(status[])
 end
 
-function fits_insert_img(f::FITSFile, T::Type, naxes::NTuple{N,Integer}; prependprimary::Bool = false) where {N}
+function fits_insert_img(f::FITSFile, T::Type, naxes::NTuple{N,Integer}; prepend_primary::Bool = false) where {N}
     fits_assert_open(f)
 
-    status = Ref{Cint}(prependprimary ? PREPEND_PRIMARY : 0)
+    status = Ref{Cint}(prepend_primary ? PREPEND_PRIMARY : 0)
     naxesr = Ref(map(Int64, naxes))
     ccall(
         (:ffiimgll, libcfitsio),
@@ -1189,7 +1193,7 @@ function fits_insert_img(f::FITSFile, T::Type, naxes::NTuple{N,Integer}; prepend
     fits_assert_ok(status[])
 end
 
-fits_insert_img(f::FITSFile, a::AbstractArray{<:Real}; prependprimary::Bool = false) = fits_insert_img(f, eltype(a), size(a); prependprimary=prependprimary)
+fits_insert_img(f::FITSFile, a::AbstractArray{<:Real}; prepend_primary::Bool = false) = fits_insert_img(f, eltype(a), size(a); prepend_primary=prepend_primary)
 
 """
     fits_write_pix(f::FITSFile,

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1145,7 +1145,7 @@ of storing the array `a`. The flag `prependprimary` may be specified to insert a
 function fits_insert_img(f::FITSFile, T::Type, naxes::Vector{<:Integer}; prependprimary::Bool = false)
     fits_assert_open(f)
 
-    status = Ref{Cint}(prependprimary * PREPEND_PRIMARY)
+    status = Ref{Cint}(prependprimary ? PREPEND_PRIMARY : 0)
     ccall(
         (:ffiimgll, libcfitsio),
         Cint,
@@ -1168,7 +1168,7 @@ end
 function fits_insert_img(f::FITSFile, T::Type, naxes::NTuple{N,Integer}; prependprimary::Bool = false) where {N}
     fits_assert_open(f)
 
-    status = Ref{Cint}(prependprimary * PREPEND_PRIMARY)
+    status = Ref{Cint}(prependprimary ? PREPEND_PRIMARY : 0)
     naxesr = Ref(map(Int64, naxes))
     ccall(
         (:ffiimgll, libcfitsio),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -282,6 +282,17 @@ end
                 fits_movabs_hdu(f, 2)
                 fits_read_pix(f, b)
                 @test b == ones(2,2) .* 4
+                # Insert new primary image
+                for sz in Any[[1,2,3], (2,4)]
+                    fits_movabs_hdu(f, 1)
+                    sz_exist = fits_get_img_size(f)
+                    fits_insert_img(f, Int, sz, true)
+                    @test fits_get_hdu_num(f) == 1
+                    @test fits_get_img_size(f) == [sz...]
+                    # test that the primary HDU is converted to an image
+                    fits_movabs_hdu(f, 2)
+                    @test fits_get_img_size(f) == sz_exist
+                end
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,7 +286,7 @@ end
                 for sz in Any[[1,2,3], (2,4)]
                     fits_movabs_hdu(f, 1)
                     sz_exist = fits_get_img_size(f)
-                    fits_insert_img(f, Int, sz, true)
+                    fits_insert_img(f, Int, sz, prepend_primary=true)
                     @test fits_get_hdu_num(f) == 1
                     @test fits_get_img_size(f) == [sz...]
                     # test that the primary HDU is converted to an image


### PR DESCRIPTION
Uses `PREPEND_PRIMARY` as discussed in #16 . Currently I've hard-coded the value here, which is not ideal. This allows one to insert a new primary HDU and convert the pre-existing one to an image HDU.

```julia
julia> f = fits_create_file(tempname());

julia> a = ones(3);

julia> fits_create_img(f, a); fits_write_pix(f, a);

julia> fits_get_img_size(f)
1-element Vector{Int64}:
 3

julia> fits_insert_img(f, Float64, [3,2], true); # insert new primary image

julia> fits_get_hdu_num(f) # check that the current HDU index is still 1
1

julia> fits_get_img_size(f) # the original HDU has been replaced
2-element Vector{Int64}:
 3
 2

julia> fits_movabs_hdu(f, 2) # the original primary HDU is now an image
:image_hdu

julia> fits_get_img_size(f)
1-element Vector{Int64}:
 3
```