### PR TITLE
Add missing data type (UInt64/Culonglong)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CFITSIO"
 uuid = "3b1b4be9-1499-4b22-8d78-7db3344d1961"
 authors = ["Miles Lucas <mdlucas@hawaii.edu> and contributors"]
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 CFITSIO_jll = "b3e40c51-02ae-5482-8a39-3ace5868dcf4"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,6 +52,7 @@ the BITPIX keyword and Julia types.
 |                    10 	| SBYTE_IMG    	| `Int8`            | written as: BITPIX = 8, BSCALE = 1, BZERO = -128        	|
 |                    20 	| USHORT_IMG   	| `Uint16`          | written as: BITPIX = 16, BSCALE = 1, BZERO = 32768      	|
 |                    40 	| LONG_IMG     	| `Uint32`          | written as: BITPIX = 32, BSCALE = 1, BZERO = 2147483648 	|
+|                    80 	| ULONGLONG_IMG	| `UInt64`          | written as: BITPIX = 64, BSCALE = 1, BZERO = 9223372036854775808 	|
 
 ### FITS Table Data Types
 |                  CODE 	| CFITSIO      	| Julia            	 |
@@ -68,6 +69,7 @@ the BITPIX keyword and Julia types.
 |                    40 	| TULONG       	| `Culong`           |
 |                    41 	| TLONG        	| `Clong`            |
 |                    42 	| TFLOAT       	| `Cfloat`           	|
+|                    80 	| TULONGLONG   	| `UInt64`           |
 |                    81 	| TLONGLONG    	| `Int64`            |
 |                    82 	| TDOUBLE      	| `Cdouble`          |
 |                    83 	| TCOMPLEX     	| `Complex{Cfloat}`  	|

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -110,6 +110,7 @@ for (T, code) in (
     (Cshort, 21),
     (Cuint, 30),
     (Cint, 31),
+    (UInt64, 80),
     (Int64, 81),
     (Float32, 42),
     (Float64, 82),
@@ -127,7 +128,8 @@ for (T, code) in ((UInt8,     8), # BYTE_IMG
                   (Float64, -64), # DOUBLE_IMG
                   (Int8,     10), # SBYTE_IMG
                   (UInt16,   20), # USHORT_IMG
-                  (UInt32,   40)) # ULONG_IMG
+                  (UInt32,   40), # ULONG_IMG
+                  (UInt64,   80)) # ULONGLONG_IMG
     local value = Cint(code)
     @eval begin
         bitpix_from_type(::Type{$T}) = $value
@@ -138,11 +140,7 @@ type_from_bitpix(code::Integer) = type_from_bitpix(Val(Cint(code)))
 
 # Above, we don't define a method for Clong because it is either Cint (Int32)
 # or Int64 depending on the platform, and those methods are already defined.
-# Culong is either UInt64 or Cuint depending on platform. Only define it if
-# not already defined.
-if Culong !== Cuint
-    cfitsio_typecode(::Type{Culong}) = Cint(40)
-end
+# Culong is either UInt64 or Cuint depending on platform.
 
 # -----------------------------------------------------------------------------
 # FITSFile type

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,6 +157,7 @@ end
             (Cshort, 21),
             (Cuint, 30),
             (Cint, 31),
+            (UInt64, 80),
             (Int64, 81),
             (Float32, 42),
             (Float64, 82),
@@ -174,7 +175,8 @@ end
                         (Float64, -64), # DOUBLE_IMG
                         (Int8,     10), # SBYTE_IMG
                         (UInt16,   20), # USHORT_IMG
-                        (UInt32,   40)) # ULONG_IMG
+                        (UInt32,   40), # ULONG_IMG
+                        (UInt64,   80)) # ULONGLONG_IMG
             @test bitpix_from_type(T) == code
             @test type_from_bitpix(Cint(code)) == type_from_bitpix(Val(Cint(code))) == T
             @test type_from_bitpix(Int16(code)) == T


### PR DESCRIPTION
CFITSIO definitions for reference:
<https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node20.html>

Example file to reproduce error:
<https://data.sdss.org/sas/dr18/spectro/sdss/redux/v5_13_2/spectra/lite/3650/spec-3650-55244-0001.fits>

MWE/MRE:
```julia
using FITSIO
fits = FITS("spec-3650-55244-0001.fits")
hdu = fits["SPALL"]
read(hdu, "SPECOBJID")
```

This pr with https://github.com/JuliaAstro/FITSIO.jl/pull/193 will fix error(s) including:
* `KeyError: key 80 not found`
* `MethodError: no method matching cfitsio_typecode(::Type{UInt64})`

