### PR TITLE
Add GC preserve to unsafe_string conversions from pointer

### DIFF
--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -193,21 +193,23 @@ function Base.showerror(io::IO, c::CFITSIOError)
     end
 end
 
+tostring(v) = GC.@preserve v unsafe_string(pointer(v))
+
 function fits_get_errstatus(status::Cint)
     msg = Vector{UInt8}(undef, 31)
     ccall((:ffgerr, libcfitsio), Cvoid, (Cint, Ptr{UInt8}), status, msg)
-    unsafe_string(pointer(msg))
+    tostring(msg)
 end
 
 function fits_read_errmsg()
     msg = Vector{UInt8}(undef, 80)
     msgstr = ""
     ccall((:ffgmsg, libcfitsio), Cvoid, (Ptr{UInt8},), msg)
-    msgstr = unsafe_string(pointer(msg))
+    msgstr = tostring(msg)
     errstr = msgstr
     while msgstr != ""
         ccall((:ffgmsg, libcfitsio), Cvoid, (Ptr{UInt8},), msg)
-        msgstr = unsafe_string(pointer(msg))
+        msgstr = tostring(msg)
         errstr *= '\n' * msgstr
     end
     return errstr
@@ -469,7 +471,7 @@ function fits_file_name(f::FITSFile)
         status,
     )
     fits_assert_ok(status[])
-    unsafe_string(pointer(value))
+    tostring(value)
 end
 
 """
@@ -538,7 +540,7 @@ function fits_read_key_str(f::FITSFile, keyname::String)
         status,
     )
     fits_assert_ok(status[])
-    unsafe_string(pointer(value)), unsafe_string(pointer(comment))
+    tostring(value), tostring(comment)
 end
 
 function fits_read_key_lng(f::FITSFile, keyname::String)
@@ -557,7 +559,7 @@ function fits_read_key_lng(f::FITSFile, keyname::String)
         status,
     )
     fits_assert_ok(status[])
-    value[], unsafe_string(pointer(comment))
+    value[], tostring(comment)
 end
 
 function fits_read_keys_lng(f::FITSFile, keyname::String, nstart::Integer, nmax::Integer)
@@ -604,7 +606,7 @@ function fits_read_keyword(f::FITSFile, keyname::String)
         status,
     )
     fits_assert_ok(status[])
-    unsafe_string(pointer(value)), unsafe_string(pointer(comment))
+    tostring(value), tostring(comment)
 end
 
 
@@ -628,7 +630,7 @@ function fits_read_record(f::FITSFile, keynum::Integer)
         status,
     )
     fits_assert_ok(status[])
-    unsafe_string(pointer(card))
+    tostring(card)
 end
 
 
@@ -656,9 +658,9 @@ function fits_read_keyn(f::FITSFile, keynum::Integer)
     )
     fits_assert_ok(status[])
     (
-        unsafe_string(pointer(keyname)),
-        unsafe_string(pointer(value)),
-        unsafe_string(pointer(comment)),
+        tostring(keyname),
+        tostring(value),
+        tostring(comment),
     )
 end
 


### PR DESCRIPTION
My understanding is that this is the way to ensure that the vector is not garbage-collected during the operation, which may lead to segfaults.