### PR TITLE
Remove tests on julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
         version:
           - "1.3"
           - "1"
-          - "nightly"
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
I feel the nightly is too unstable to be tested against as a part of the package CI, and one may always access the `PkgEval` logs if they want to look at test failures on nightly.