### PR TITLE
GC_preserve coldefs in create_(binary/ascii)_table

### DIFF
--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -2171,35 +2171,37 @@ for (a, b) in ((:fits_create_binary_tbl, 2), (:fits_create_ascii_tbl, 1))
 
             # get length and convert coldefs to three arrays of Ptr{Uint8}
             ntype = length(coldefs)
-            ttype = [pointer(x[1]) for x in coldefs]
-            tform = [pointer(x[2]) for x in coldefs]
-            tunit = [pointer(x[3]) for x in coldefs]
-            status = Ref{Cint}(0)
+            GC.@preserve coldefs begin
+                ttype = [pointer(x[1]) for x in coldefs]
+                tform = [pointer(x[2]) for x in coldefs]
+                tunit = [pointer(x[3]) for x in coldefs]
+                status = Ref{Cint}(0)
 
-            ccall(
-                ("ffcrtb", libcfitsio),
-                Cint,
-                (
-                    Ptr{Cvoid},
+                ccall(
+                    ("ffcrtb", libcfitsio),
                     Cint,
-                    Int64,
-                    Cint,
-                    Ptr{Ptr{UInt8}},
-                    Ptr{Ptr{UInt8}},
-                    Ptr{Ptr{UInt8}},
-                    Ptr{UInt8},
-                    Ref{Cint},
-                ),
-                f.ptr,
-                $b,
-                numrows,
-                ntype,
-                ttype,
-                tform,
-                tunit,
-                extname,
-                status,
-            )
+                    (
+                        Ptr{Cvoid},
+                        Cint,
+                        Int64,
+                        Cint,
+                        Ptr{Ptr{UInt8}},
+                        Ptr{Ptr{UInt8}},
+                        Ptr{Ptr{UInt8}},
+                        Ptr{UInt8},
+                        Ref{Cint},
+                    ),
+                    f.ptr,
+                    $b,
+                    numrows,
+                    ntype,
+                    ttype,
+                    tform,
+                    tunit,
+                    extname,
+                    status,
+                )
+            end
             fits_assert_ok(status[])
         end
     end


### PR DESCRIPTION
This should ensure that the variable isn't freed while a `pointer` to it is being used.