### PR TITLE
Address #34 and FITSIO.jl#196

### DIFF
--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1,5 +1,4 @@
 module CFITSIO
-
 using CFITSIO_jll
 
 export FITSFile,
@@ -2485,8 +2484,7 @@ function fits_read_col(
     abs(typecode) == 16 || error("not a string column")
 
     # create an array of character buffers of the correct width
-    buffers = [Vector{UInt8}(undef, width) for i in 1:length(data)]
-
+    buffers = [Vector{UInt8}(undef, width*repcount) for i in 1:length(data)]
     # Call the CFITSIO function
     anynull = Ref{Cint}(0)
     status = Ref{Cint}(0)


### PR DESCRIPTION
I believe this small change addresses at least some of the segmentation faults we've been seeing when loading fits files in Julia 1.11.

With this change, I can now load fits tables that include string columns on Julia 1.12. In addition, I can run the Healpix tests without crashing (though one possibly unrelated failure remains).


I have not been able to create a minimized test case for this problem besides uploading one of the large fits files that happens to trigger it.


I'm not 100% sure that this new allocation size is correct, vs just being large enough to avoid the issue...

In any case, I'm in favour of merging this asap if others find that it ameliorates the crashing they see.