### PR TITLE
Update max lengths of `UInt8` arrays

### DIFF
--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -141,6 +141,14 @@ type_from_bitpix(code::Integer) = type_from_bitpix(Val(Cint(code)))
 # or Int64 depending on the platform, and those methods are already defined.
 # Culong is either UInt64 or Cuint depending on platform.
 
+const FLEN_FILENAME = 1025 # max length of a filename  */
+const FLEN_KEYWORD =   75  # max length of a keyword (HIERARCH convention) */
+const FLEN_CARD =      81  # length of a FITS header card */
+const FLEN_VALUE =     71  # max length of a keyword value string */
+const FLEN_COMMENT =   73  # max length of a keyword comment string */
+const FLEN_ERRMSG =    81  # max length of a FITSIO error message */
+const FLEN_STATUS =    31  # max length of a FITSIO status text string */
+
 # -----------------------------------------------------------------------------
 # FITSFile type
 
@@ -195,13 +203,13 @@ end
 tostring(v) = GC.@preserve v unsafe_string(pointer(v))
 
 function fits_get_errstatus(status::Cint)
-    msg = Vector{UInt8}(undef, 31)
+    msg = Vector{UInt8}(undef, FLEN_STATUS)
     ccall((:ffgerr, libcfitsio), Cvoid, (Cint, Ptr{UInt8}), status, msg)
     tostring(msg)
 end
 
 function fits_read_errmsg()
-    msg = Vector{UInt8}(undef, 81)
+    msg = Vector{UInt8}(undef, FLEN_ERRMSG)
     msgstr = ""
     ccall((:ffgmsg, libcfitsio), Cvoid, (Ptr{UInt8},), msg)
     msgstr = tostring(msg)
@@ -461,7 +469,7 @@ Return the name of the file associated with object `f`.
 """
 function fits_file_name(f::FITSFile)
     fits_assert_open(f)
-    value = Vector{UInt8}(undef, 1025)
+    value = Vector{UInt8}(undef, FLEN_FILENAME)
     status = Ref{Cint}(0)
     ccall(
         (:ffflnm, libcfitsio),
@@ -527,8 +535,8 @@ end
 
 function fits_read_key_str(f::FITSFile, keyname::String)
     fits_assert_open(f)
-    value = Vector{UInt8}(undef, 71)
-    comment = Vector{UInt8}(undef, 73)
+    value = Vector{UInt8}(undef, FLEN_VALUE)
+    comment = Vector{UInt8}(undef, FLEN_COMMENT)
     status = Ref{Cint}(0)
     ccall(
         (:ffgkys, libcfitsio),
@@ -547,7 +555,7 @@ end
 function fits_read_key_lng(f::FITSFile, keyname::String)
     fits_assert_open(f)
     value = Ref{Clong}(0)
-    comment = Vector{UInt8}(undef, 73)
+    comment = Vector{UInt8}(undef, FLEN_COMMENT)
     status = Ref{Cint}(0)
     ccall(
         (:ffgkyj, libcfitsio),
@@ -593,8 +601,8 @@ throws and error if the keyword is not found.
 """
 function fits_read_keyword(f::FITSFile, keyname::String)
     fits_assert_open(f)
-    value = Vector{UInt8}(undef, 71)
-    comment = Vector{UInt8}(undef, 73)
+    value = Vector{UInt8}(undef, FLEN_VALUE)
+    comment = Vector{UInt8}(undef, FLEN_COMMENT)
     status = Ref{Cint}(0)
     ccall(
         (:ffgkey, libcfitsio),
@@ -619,7 +627,7 @@ header is at `keynum = 1`.
 """
 function fits_read_record(f::FITSFile, keynum::Integer)
     fits_assert_open(f)
-    card = Vector{UInt8}(undef, 81)
+    card = Vector{UInt8}(undef, FLEN_CARD)
     status = Ref{Cint}(0)
     ccall(
         (:ffgrec, libcfitsio),
@@ -642,9 +650,12 @@ Return the nth header record in the CHU. The first keyword in the header is at `
 """
 function fits_read_keyn(f::FITSFile, keynum::Integer)
     fits_assert_open(f)
-    keyname = Vector{UInt8}(undef, 9)
-    value = Vector{UInt8}(undef, 71)
-    comment = Vector{UInt8}(undef, 73)
+    # CFITSIO follows the ESO HIERARCH convention where
+    # keyword names may be longer than 8 characters (which is the FITS standard)
+    # https://heasarc.gsfc.nasa.gov/fitsio/c/f_user/node28.html
+    keyname = Vector{UInt8}(undef, FLEN_KEYWORD)
+    value = Vector{UInt8}(undef, FLEN_VALUE)
+    comment = Vector{UInt8}(undef, FLEN_COMMENT)
     status = Ref{Cint}(0)
     ccall(
         (:ffgkyn, libcfitsio),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -790,4 +790,20 @@ end
             rm(filename)
         end
     end
+
+    @testset "read keyword" begin
+        tempfitsfile() do f
+            CFITSIO.fits_create_img(f, Int16, (10,10))
+            CFITSIO.fits_write_key(f, "DUMMYKEY", "DummyValue", "This is a test keyword")
+            val, comment = CFITSIO.fits_read_keyword(f, "DUMMYKEY")
+            @test occursin("DummyValue", val)
+            @test comment == "This is a test keyword"
+
+            # Read the 9th header record — first 8 are standard FITS keywords
+            record_str = CFITSIO.fits_read_record(f, 9)
+            @test occursin("DUMMYKEY", record_str)
+            @test occursin("DummyValue", record_str)
+            @test occursin("This is a test keyword", record_str)
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -804,6 +804,11 @@ end
             @test occursin("DUMMYKEY", record_str)
             @test occursin("DummyValue", record_str)
             @test occursin("This is a test keyword", record_str)
+
+            keyname, value, comment = CFITSIO.fits_read_keyn(f, 9)
+            @test keyname == "DUMMYKEY"
+            @test occursin("DummyValue", value)
+            @test comment == "This is a test keyword"
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -811,4 +811,24 @@ end
             @test comment == "This is a test keyword"
         end
     end
+
+    @testset "memfile" begin
+        tempfitsfile() do f
+            CFITSIO.fits_create_img(f, Int16, (2,2))
+            CFITSIO.fits_write_key(f, "EXAMPLE", 42, "Memory test")
+            filename = CFITSIO.fits_file_name(f)
+            close(f)
+
+            file_bytes = read(filename)
+            nbytes = length(file_bytes)
+            buffer = Vector{UInt8}(file_bytes)  # Mutable buffer for CFITSIO
+
+            fmem, handle = CFITSIO.fits_open_memfile(buffer, CFITSIO.R)
+            val, comment = CFITSIO.fits_read_keyword(fmem, "EXAMPLE")
+            @test val == "42"
+            @test comment == "Memory test"
+
+            close(fmem)
+        end
+    end
 end


### PR DESCRIPTION
This matches the values in https://github.com/HEASARC/cfitsio/blob/01303466dc26cdba256c2fcb44b0f70f3f78912e/fitsio.h#L214-L220. Ideally, we should be reading these in directly from `fitsio.h`, but I don't know how to do that.

Firstly, in `fits_read_errmsg`, the error message is 80 chars, so the array needs to be 81 chars to account for the null terminator. Secondly, `comment` needs to be 73 characters, and not 71, as FITS comments can be up to 72 chars.

I've also added a `GC.@preserve` to `data` in `fits_open_memfile`. This isn't strictly necessary for this PR, but I think this should reduce the chances of errors.