### PR TITLE
Add verbose file opening modes

### DIFF
--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -82,6 +82,8 @@ export FITSFile,
 
 
 @enum FileMode R = 0 RW = 1
+@enum FileModeVerbose READONLY = Int(R) READWRITE = Int(RW)
+
 const PREPEND_PRIMARY = -9 # copied from fitsio.h
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,19 +130,19 @@ end
             close(f)
 
             f = fits_open_file(filename, 0)
-            @test fits_file_mode(f) == 0 == Int(CFITSIO.R)
+            @test fits_file_mode(f) == 0 == Int(CFITSIO.READONLY) == Int(CFITSIO.R)
             close(f)
 
-            f = fits_open_file(filename, CFITSIO.R)
-            @test fits_file_mode(f) == 0 == Int(CFITSIO.R)
+            f = fits_open_file(filename, CFITSIO.READONLY)
+            @test fits_file_mode(f) == 0 == Int(CFITSIO.READONLY) == Int(CFITSIO.R)
             close(f)
 
             f = fits_open_file(filename, 1)
-            @test fits_file_mode(f) == 1 == Int(CFITSIO.RW)
+            @test fits_file_mode(f) == 1 == Int(CFITSIO.READWRITE) == Int(CFITSIO.RW)
             close(f)
 
-            f = fits_open_file(filename, CFITSIO.RW)
-            @test fits_file_mode(f) == 1 == Int(CFITSIO.RW)
+            f = fits_open_file(filename, CFITSIO.READWRITE)
+            @test fits_file_mode(f) == 1 == Int(CFITSIO.READWRITE) == Int(CFITSIO.RW)
             close(f)
         end
     end


### PR DESCRIPTION
Currently, we have the `CFITSIO.R` and `CFITSIO.RW` file modes. This adds the equivalent but more verbose `CFITSIO.READONLY` and `CFITSIO.READWRITE` modes, which are easier to read. These match the constants that are defined in the C code. These also parallel astropy, which uses the string "readonly" alongside others.

In addition (although this isn't the most important point), ChatGPT seems to incorrectly suggest `CFITSIO.READONLY` as a valid file mode, and having this available would help with vibe coding.   