### PR TITLE
Add `fits_create_empty_img`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -146,6 +146,7 @@ fits_copy_header
 ```@docs
 fits_get_img_size
 fits_create_img
+fits_create_empty_img
 fits_insert_img
 fits_write_pix
 fits_write_pixnull

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1134,7 +1134,7 @@ end
     fits_create_empty_img(f::FITSFile)
 
 Create an empty image HDU with no dimensions, and of type `Int`.
-See [fits_create_img](@ref).
+See [`fits_create_img`](@ref).
 """
 fits_create_empty_img(f::FITSFile) = fits_create_img(f, Int, C_NULL)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,6 +259,8 @@ end
                 close(f)
                 f = fits_open_file(filename)
                 @test fits_get_num_hdus(f) == 1
+                @test fits_get_img_dim(f) == 0
+                @test fits_get_img_size(f) == Int[]
             end
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,13 +6,14 @@ function tempfitsfile(fn)
     mktempdir() do dir
         filename = joinpath(dir, "temp.fits")
         fitsfile = fits_clobber_file(filename)
-        fn(fitsfile)
-
-        if fitsfile.ptr != C_NULL
-            # write some data to file to avoid errors on closing
-            data = ones(1)
-            fits_create_img(fitsfile, data)
-            fits_write_pix(fitsfile, data)
+        try
+            fn(fitsfile)
+        finally
+            if fitsfile.ptr != C_NULL
+                # write some data to file to avoid errors on closing
+                fits_create_empty_img(fitsfile)
+            end
+            fits_close_file(fitsfile)
             fits_delete_file(fitsfile)
         end
     end
@@ -249,6 +250,16 @@ end
             @test fits_get_num_hdus(f) == 2
             @test fits_get_hdu_num(f) == 1
             @test fits_get_img_dim(f) == 0
+        end
+
+        @testset "empty hdu" begin
+            tempfitsfile() do f
+                fits_create_empty_img(f)
+                filename = fits_file_name(f)
+                close(f)
+                f = fits_open_file(filename)
+                @test fits_get_num_hdus(f) == 1
+            end
         end
 
         @testset "insert image" begin


### PR DESCRIPTION
This implements the suggestion from https://github.com/JuliaAstro/CFITSIO.jl/issues/19, and creates an empty image with no dimensions. This is useful to create a dummy primary array.