### PR TITLE
Assert types when accepting preallocated arrays

### DIFF
--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -213,18 +213,19 @@ tostring(v) = GC.@preserve v unsafe_string(pointer(v))
 
 fits_get_errstatus_buffer() = (; err_text = Vector{UInt8}(undef, FLEN_STATUS))
 function fits_get_errstatus(status::Cint; err_text = fits_get_errstatus_buffer().err_text)
-    ccall((:ffgerr, libcfitsio), Cvoid, (Cint, Ptr{UInt8}), status, err_text)
+    ccall((:ffgerr, libcfitsio), Cvoid, (Cint, Ptr{UInt8}), status, convert(Vector{UInt8}, err_text))
     tostring(err_text)
 end
 
 fits_read_errmsg_buffer() = (; err_msg = Vector{UInt8}(undef, FLEN_ERRMSG))
 function fits_read_errmsg(; err_msg = fits_read_errmsg_buffer().err_msg)
     msgstr = ""
-    ccall((:ffgmsg, libcfitsio), Cvoid, (Ptr{UInt8},), err_msg)
+    err_msg_UInt8 = convert(Vector{UInt8}, err_msg)
+    ccall((:ffgmsg, libcfitsio), Cvoid, (Ptr{UInt8},), err_msg_UInt8)
     msgstr = tostring(err_msg)
     errstr = msgstr
     while msgstr != ""
-        ccall((:ffgmsg, libcfitsio), Cvoid, (Ptr{UInt8},), err_msg)
+        ccall((:ffgmsg, libcfitsio), Cvoid, (Ptr{UInt8},), err_msg_UInt8)
         msgstr = tostring(err_msg)
         errstr *= '\n' * msgstr
     end
@@ -478,7 +479,7 @@ function fits_file_name(f::FITSFile; filename = fits_file_name_buffer().filename
         Cint,
         (Ptr{Cvoid}, Ptr{UInt8}, Ref{Cint}),
         f.ptr,
-        filename,
+        convert(Vector{UInt8}, filename),
         status,
     )
     fits_assert_ok(status[])
@@ -552,8 +553,8 @@ function fits_read_key_str(f::FITSFile, keyname::String;
         (Ptr{Cvoid}, Cstring, Ptr{UInt8}, Ptr{UInt8}, Ref{Cint}),
         f.ptr,
         keyname,
-        value,
-        comment,
+        convert(Vector{UInt8}, value),
+        convert(Vector{UInt8}, comment),
         status,
     )
     fits_assert_ok(status[])
@@ -573,7 +574,7 @@ function fits_read_key_lng(f::FITSFile, keyname::String;
         f.ptr,
         keyname,
         value,
-        comment,
+        convert(Vector{UInt8}, comment),
         status,
     )
     fits_assert_ok(status[])
@@ -594,7 +595,7 @@ function fits_read_keys_lng(f::FITSFile, keyname::String, nstart::Integer, nmax:
         keyname,
         nstart,
         nmax,
-        value,
+        convert(Vector{Clong}, value),
         nfound,
         status,
     )
@@ -626,8 +627,8 @@ function fits_read_keyword(f::FITSFile, keyname::String;
         (Ptr{Cvoid}, Cstring, Ptr{UInt8}, Ptr{UInt8}, Ref{Cint}),
         f.ptr,
         keyname,
-        value,
-        comment,
+        convert(Vector{UInt8}, value),
+        convert(Vector{UInt8}, comment),
         status,
     )
     fits_assert_ok(status[])
@@ -652,7 +653,7 @@ function fits_read_record(f::FITSFile, keynum::Integer;
         (Ptr{Cvoid}, Cint, Ptr{UInt8}, Ref{Cint}),
         f.ptr,
         keynum,
-        card,
+        convert(Vector{UInt8}, card),
         status,
     )
     fits_assert_ok(status[])
@@ -688,9 +689,9 @@ function fits_read_keyn(f::FITSFile, keynum::Integer;
         (Ptr{Cvoid}, Cint, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}, Ref{Cint}),
         f.ptr,
         keynum,
-        keyname,
-        value,
-        comment,
+        convert(Vector{UInt8}, keyname),
+        convert(Vector{UInt8}, value),
+        convert(Vector{UInt8}, comment),
         status,
     )
     fits_assert_ok(status[])
@@ -2648,7 +2649,7 @@ function fits_get_coltype end
             colnum,
             length(naxes),
             naxis,
-            naxes,
+            convert(Vector{$Clong_or_Clonglong}, naxes),
             status,
         )
         fits_assert_ok(status[])

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -212,7 +212,7 @@ end
 tostring(v) = GC.@preserve v unsafe_string(pointer(v))
 
 fits_get_errstatus_buffer() = (; err_text = Vector{UInt8}(undef, FLEN_STATUS))
-function fits_get_errstatus(status::Cint; err_text::Vector{UInt8} = fits_get_errstatus_buffer().err_text)
+function fits_get_errstatus(status::Integer; err_text::Vector{UInt8} = fits_get_errstatus_buffer().err_text)
     ccall((:ffgerr, libcfitsio), Cvoid, (Cint, Ptr{UInt8}), status, err_text)
     tostring(err_text)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -985,6 +985,25 @@ end
         @test :keyname in keys(buf)
         @test :value in keys(buf)
         @test :comment in keys(buf)
+
+        @testset "incorrect types error" begin
+            tempfitsfile() do f
+                @test_throws TypeError fits_file_name(f, filename = Int[2])
+                @test_throws TypeError fits_read_keyn(f, 1, keyname = Int[2])
+                @test_throws TypeError fits_read_keyn(f, 1, value = Int[2])
+                @test_throws TypeError fits_read_keyn(f, 1, comment = Int[2])
+                @test_throws TypeError fits_read_record(f, 1, card = Int[2])
+                @test_throws TypeError fits_read_keyword(f, "DUMMYKEY", value = Int[2])
+                @test_throws TypeError fits_read_keyword(f, "DUMMYKEY", comment = Int[2])
+                @test_throws TypeError fits_read_keys_lng(f, "DUMMYKEY", 1, 2, value = Float64[2])
+                @test_throws TypeError fits_read_key_lng(f, "DUMMYKEY", comment = Float64[2])
+                @test_throws TypeError fits_read_tdim(f, 1, naxes = Float64[2])
+                @test_throws TypeError CFITSIO.fits_read_errmsg(err_msg = Int[2])
+                @test_throws TypeError CFITSIO.fits_get_errstatus(1, err_text = Int[2])
+                @test_throws TypeError fits_read_key_str(f, "DUMMYKEY", value = Int[2])
+                @test_throws TypeError fits_read_key_str(f, "DUMMYKEY", comment = Int[2])
+            end
+        end
     end
 
     @testset "write to and read from ascii table" begin


### PR DESCRIPTION
Since we are now accepting arbitrary inputs, we need to ensure that they are of the correct type.