### PR TITLE
Allow skipping units and extname in table creation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CFITSIO"
 uuid = "3b1b4be9-1499-4b22-8d78-7db3344d1961"
 authors = ["Miles Lucas <mdlucas@hawaii.edu> and contributors"]
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 CFITSIO_jll = "b3e40c51-02ae-5482-8a39-3ace5868dcf4"

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -2562,8 +2562,8 @@ const ColumnDef = Tuple{String,String,String}
 
 """
     fits_create_binary_tbl(f::FITSFile, numrows::Integer,
-                           coldefs::Array{Tuple{String,String,String}},
-                           extname::String)
+                           coldefs::Union{Array{NTuple{3,String}}, Array{NTuple{2,String}}},
+                           extname::Union{String, Nothing} = nothing)
 
 Append a new HDU containing a binary table. The meaning of the parameters is the same
 as in a call to [`fits_create_ascii_tbl`](@ref).
@@ -2576,8 +2576,8 @@ function fits_create_binary_tbl end
 
 """
     fits_create_ascii_tbl(f::FITSFile, numrows::Integer,
-                          coldefs::Array{Tuple{String,String,String}},
-                          extname::String)
+                          coldefs::Union{Array{NTuple{3,String}}, Array{NTuple{2,String}}},
+                          extname::Union{String, Nothing} = nothing)
 
 Append a new HDU containing an ASCII table.
 
@@ -2585,7 +2585,7 @@ The table will have `numrows` rows (this parameter can be set to zero), each
 initialized with the default value. In order to create a table, the programmer
 must specify the characteristics of each column. The columns are specified by the
 `coldefs` variable, which is an array of tuples.
-Each tuple must have three string fields:
+Each tuple must have two or three string fields:
 
 1. The name of the column.
 2. The data type and the repetition count. It must be a string made by a number
@@ -2593,17 +2593,23 @@ Each tuple must have three string fields:
    above, `D` stands for `Float64`, `E` stands for `Float32`, `A` stands for `Char`).
    Refer to the CFITSIO documentation for more information about the syntax of this
    parameter.
-3. The measure unit of this field. This is used only as a comment.
+3. The unit of this field. This is used to set the corresponding `TUNITn` keywords.
+   If `coldefs` is a two-tuple, the unit keywords are left unset.
+   If the third field of a tuple is an empty string,
+   the corresponding unit keyword is also left unset.
 
 The value of `extname` sets the "extended name" of the table, i.e., a string
-that in some situations can be used to refer to the HDU itself.
+that in some situations can be used to refer to the HDU itself. This may be omitted by setting
+`extname` to `nothing` (which is the default behavior).
 
 Note that, unlike for binary tables, CFITSIO puts some limitations to the
 types that can be used in an ASCII table column. Refer to the CFITSIO manual
 for further information.
 
 See also [`fits_create_binary_tbl`](@ref) for a similar function which
-creates binary tables.
+creates binary tables. In general, one should pick this function for creating tables in a new HDU,
+as binary tables require less space on the disk and are more efficient to read and write.
+(Moreover, a few datatypes are not supported in ASCII tables).
 """
 function fits_create_ascii_tbl end
 
@@ -2626,7 +2632,7 @@ for (a, b) in ((:fits_create_binary_tbl, BINARY_TBL), (:fits_create_ascii_tbl, A
                 numrows::Integer,
                 ttype::Vector{String},
                 tform::Vector{String},
-                tunit::Union{Vector{String}, Nothing},
+                tunit::Union{Vector{String}, Nothing} = nothing,
                 extname::Union{String, Nothing} = nothing,
                 )
 
@@ -2644,7 +2650,8 @@ for (a, b) in ((:fits_create_binary_tbl, BINARY_TBL), (:fits_create_ascii_tbl, A
 end
 
 function fits_create_tbl(f::FITSFile, tbltype, numrows::Integer,
-        ttype::Vector{String}, tform::Vector{String}, tunit::Union{Vector{String}, Nothing},
+        ttype::Vector{String}, tform::Vector{String},
+        tunit::Union{Vector{String}, Nothing} = nothing,
         extname::Union{String, Nothing} = nothing)
 
     Int(tbltype) in (Int(ASCII_TBL), Int(BINARY_TBL)) ||

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -640,6 +640,12 @@ end
                 @test tunit == ["counts", "K"]
                 buf = CFITSIO.fits_read_atblhdr_buffer(3)
                 @test fits_read_atblhdr(f, 3) == fits_read_atblhdr(f, 3; buf...)
+                @testset "skip units and extname" begin
+                    fits_create_ascii_tbl(f, 0, [("A", "I4"), ("B", "F10.2")])
+                    rowlen, nrows, tfields, ttype, tbcol, tform, tunit, extname = fits_read_atblhdr(f, 1)
+                    @test all(==(""), tunit)
+                    @test extname == ""
+                end
                 @testset "null arguments" begin
                     allvals = fits_read_atblhdr(f)
                     @testset for kw in Any[(; ttype=nothing),
@@ -671,6 +677,12 @@ end
                 @test tunit == ["counts", "K"]
                 buf = CFITSIO.fits_read_btblhdr_buffer(3)
                 @test fits_read_btblhdr(f, 3) == fits_read_btblhdr(f, 3; buf...)
+                @testset "skip units and extname" begin
+                    fits_create_binary_tbl(f, 0, [("A", "J"), ("B", "D")])
+                    nrows, tfields, ttype, tform, tunit, extname, pcount = fits_read_btblhdr(f, 1)
+                    @test all(==(""), tunit)
+                    @test extname == ""
+                end
                 @testset "null arguments" begin
                     allvals = fits_read_btblhdr(f)
                     @testset for kw in Any[(; ttype=nothing),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -642,7 +642,11 @@ end
                 @test fits_read_atblhdr(f, 3) == fits_read_atblhdr(f, 3; buf...)
                 @testset "skip units and extname" begin
                     fits_create_ascii_tbl(f, 0, [("A", "I4"), ("B", "F10.2")])
-                    rowlen, nrows, tfields, ttype, tbcol, tform, tunit, extname = fits_read_atblhdr(f, 1)
+                    rowlen, nrows, tfields, ttype, tbcol, tform, tunit, extname = fits_read_atblhdr(f)
+                    @test all(==(""), tunit)
+                    @test extname == ""
+                    fits_create_ascii_tbl(f, 0, ["A", "B"], ["I4", "F10.2"])
+                    rowlen, nrows, tfields, ttype, tbcol, tform, tunit, extname = fits_read_atblhdr(f)
                     @test all(==(""), tunit)
                     @test extname == ""
                 end
@@ -679,7 +683,11 @@ end
                 @test fits_read_btblhdr(f, 3) == fits_read_btblhdr(f, 3; buf...)
                 @testset "skip units and extname" begin
                     fits_create_binary_tbl(f, 0, [("A", "J"), ("B", "D")])
-                    nrows, tfields, ttype, tform, tunit, extname, pcount = fits_read_btblhdr(f, 1)
+                    nrows, tfields, ttype, tform, tunit, extname, pcount = fits_read_btblhdr(f)
+                    @test all(==(""), tunit)
+                    @test extname == ""
+                    fits_create_binary_tbl(f, 0, ["A", "B"], ["J", "D"])
+                    nrows, tfields, ttype, tform, tunit, extname, pcount = fits_read_btblhdr(f)
                     @test all(==(""), tunit)
                     @test extname == ""
                 end


### PR DESCRIPTION
CFITSIO allows one to skip the units and extname in creating tables by passing null pointers. In this PR, we allow passing `nothing` to the julia wrappers, which are converted to `C_NULL` in the `ccall`.