### PR TITLE
Ensure that an HDU exists in write

### DIFF
--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1714,6 +1714,7 @@ function fits_write_pix(
     )
 
     fits_assert_open(f)
+    fits_assert_nonempty(f)
 
     status = Ref{Cint}(0)
     ccall(
@@ -1746,6 +1747,7 @@ function fits_write_pix(
     ) where {N}
 
     fits_assert_open(f)
+    fits_assert_nonempty(f)
 
     status = Ref{Cint}(0)
     fpixelr = Ref(convert(NTuple{N,Int64}, fpixel))
@@ -1806,6 +1808,7 @@ function fits_write_pixnull(
     )
 
     fits_assert_open(f)
+    fits_assert_nonempty(f)
 
     status = Ref{Cint}(0)
     ccall(
@@ -1840,6 +1843,7 @@ function fits_write_pixnull(
     ) where {N}
 
     fits_assert_open(f)
+    fits_assert_nonempty(f)
     status = Ref{Cint}(0)
     fpixelr = Ref(convert(NTuple{N,Int64}, fpixel))
 

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1704,6 +1704,16 @@ function check_img_size_write(f::FITSFile, nel)
     prod(fits_get_img_size(f)) == nel ||
         throw(ArgumentError("HDU size does not match the number of elements to write $nel"))
 end
+function check_data_bounds(data, fpixel, nelements)
+    # redundant trailing indices may be ignored
+    if fpixel isa AbstractVector
+        all(isone, @view fpixel[ndims(data)+1:end]) ||
+            throw(ArgumentError("`fpixel` has trailing indices that are not 1"))
+    end
+    firstind = CartesianIndex(ntuple(i->fpixel[i], ndims(data)))
+    linind = LinearIndices(data)
+    checkbounds(linind, range(linind[firstind], length=nelements))
+end
 
 """
     fits_write_pix(f::FITSFile,
@@ -1728,6 +1738,7 @@ function fits_write_pix(
         data::StridedArray,
     )
 
+    check_data_bounds(data, fpixel, nelements)
     fits_assert_open(f)
     check_img_size_write(f, nelements)
 
@@ -1761,6 +1772,7 @@ function fits_write_pix(
     data::StridedArray,
     ) where {N}
 
+    check_data_bounds(data, fpixel, nelements)
     fits_assert_open(f)
     check_img_size_write(f, nelements)
 
@@ -1830,6 +1842,7 @@ function fits_write_pixnull(
         nulval,
     )
 
+    check_data_bounds(data, fpixel, nelements)
     fits_assert_open(f)
     check_img_size_write(f, nelements)
 
@@ -1865,6 +1878,7 @@ function fits_write_pixnull(
         nulval,
     ) where {N}
 
+    check_data_bounds(data, fpixel, nelements)
     fits_assert_open(f)
     check_img_size_write(f, nelements)
     status = Ref{Cint}(0)

--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -1694,7 +1694,7 @@ function fits_copy_data(fin::FITSFile, fout::FITSFile)
     fits_assert_ok(status[])
 end
 
-function check_img_size_write(f::FITSFile, nel)
+function validate_image_size(f::FITSFile, nel)
     # check that the required keywords exist in the header
     # this is necessary if the HDU has just been created, and
     # has not been written to disk yet
@@ -1751,7 +1751,7 @@ function fits_write_pix(
 
     check_data_bounds(data, fpixel, nelements)
     fits_assert_open(f)
-    check_img_size_write(f, nelements)
+    validate_image_size(f, nelements)
 
     status = Ref{Cint}(0)
     ccall(
@@ -1785,7 +1785,7 @@ function fits_write_pix(
 
     check_data_bounds(data, fpixel, nelements)
     fits_assert_open(f)
-    check_img_size_write(f, nelements)
+    validate_image_size(f, nelements)
 
     status = Ref{Cint}(0)
     fpixelr = Ref(convert(NTuple{N,Int64}, fpixel))
@@ -1855,7 +1855,7 @@ function fits_write_pixnull(
 
     check_data_bounds(data, fpixel, nelements)
     fits_assert_open(f)
-    check_img_size_write(f, nelements)
+    validate_image_size(f, nelements)
 
     status = Ref{Cint}(0)
     ccall(
@@ -1891,7 +1891,7 @@ function fits_write_pixnull(
 
     check_data_bounds(data, fpixel, nelements)
     fits_assert_open(f)
-    check_img_size_write(f, nelements)
+    validate_image_size(f, nelements)
     status = Ref{Cint}(0)
     fpixelr = Ref(convert(NTuple{N,Int64}, fpixel))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -537,13 +537,27 @@ end
                 rm(filename, force=true)
             end
         end
-        @testset "empty file write" begin
+        @testset "error on write without image creation" begin
+            a = ones(2,2)
             tempfitsfile() do f
-                a = ones(2,2)
+                @test_throws CFITSIO.CFITSIOError fits_write_pix(f, a)
+            end
+            tempfitsfile() do f
+                @test_throws CFITSIO.CFITSIOError fits_write_pix(f, [1,1], length(a), a)
+            end
+            tempfitsfile() do f
+                @test_throws CFITSIO.CFITSIOError fits_write_pixnull(f, a, NaN)
+            end
+            tempfitsfile() do f
+                @test_throws CFITSIO.CFITSIOError fits_write_pixnull(f, [1,1], 4, a, NaN)
+            end
+            tempfitsfile() do f
+                fits_create_empty_img(f)
                 @test_throws ArgumentError fits_write_pix(f, a)
-                @test_throws ArgumentError fits_write_pix(f, [1,1], length(a), a)
-                @test_throws ArgumentError fits_write_pixnull(f, a, NaN)
-                @test_throws ArgumentError fits_write_pixnull(f, [1,1], 4, a, NaN)
+            end
+            tempfitsfile() do f
+                fits_create_img(f, eltype(a), [size(a,1), 1])
+                @test_throws ArgumentError fits_write_pix(f, a)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -537,6 +537,15 @@ end
                 rm(filename, force=true)
             end
         end
+        @testset "empty file write" begin
+            tempfitsfile() do f
+                a = ones(2,2)
+                @test_throws ArgumentError fits_write_pix(f, a)
+                @test_throws ArgumentError fits_write_pix(f, [1,1], length(a), a)
+                @test_throws ArgumentError fits_write_pixnull(f, a, NaN)
+                @test_throws ArgumentError fits_write_pixnull(f, [1,1], 4, a, NaN)
+            end
+        end
     end
 
     @testset "closed file errors" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -573,6 +573,8 @@ end
                 @test_throws BoundsError fits_write_pixnull(f, (1,1), length(a)+1, a, NaN)
                 @test_throws BoundsError fits_write_pixnull(f, [size(a)...], 2, a, NaN)
                 @test_throws BoundsError fits_write_pixnull(f, size(a), 2, a, NaN)
+                @test_throws BoundsError fits_write_subset(f, [1,1], [3,3], a)
+                @test_throws BoundsError fits_write_subset(f, (1,1), (3,3), a)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -560,6 +560,21 @@ end
                 @test_throws ArgumentError fits_write_pix(f, a)
             end
         end
+        @testset "write beyond data" begin
+            tempfitsfile() do f
+                a = ones(2,2)
+                fits_create_img(f, a)
+                @test_throws ArgumentError fits_write_pix(f, [1,1,2], length(a), a)
+                @test_throws BoundsError fits_write_pix(f, [1,1], length(a)+1, a)
+                @test_throws BoundsError fits_write_pix(f, (1,1), length(a)+1, a)
+                @test_throws BoundsError fits_write_pix(f, [size(a)...], 2, a)
+                @test_throws BoundsError fits_write_pix(f, size(a), 2, a)
+                @test_throws BoundsError fits_write_pixnull(f, [1,1], length(a)+1, a, NaN)
+                @test_throws BoundsError fits_write_pixnull(f, (1,1), length(a)+1, a, NaN)
+                @test_throws BoundsError fits_write_pixnull(f, [size(a)...], 2, a, NaN)
+                @test_throws BoundsError fits_write_pixnull(f, size(a), 2, a, NaN)
+            end
+        end
     end
 
     @testset "closed file errors" begin


### PR DESCRIPTION
This avoids a segfault in writing to an empty fits file. One should create an image HDU first before writing to it.