### PR TITLE
Change pixels vector to tuple in `fits_read_pix`

### DIFF
--- a/src/CFITSIO.jl
+++ b/src/CFITSIO.jl
@@ -2277,11 +2277,11 @@ any null value present in the array.
 See also: [`fits_read_pixnull`](@ref)
 """
 function fits_read_pix(f::FITSFile, data::StridedArray)
-    fits_read_pix(f, ones(Int64, fits_get_img_dim(f)), length(data), data)
+    fits_read_pix(f, onest(Int64, fits_get_img_dim(f)), length(data), data)
 end
 
 function fits_read_pix(f::FITSFile, data::StridedArray, nulval)
-    fits_read_pix(f, ones(Int64, fits_get_img_dim(f)), length(data), nulval, data)
+    fits_read_pix(f, onest(Int64, fits_get_img_dim(f)), length(data), nulval, data)
 end
 
 """
@@ -2402,7 +2402,7 @@ At output, the indices of `nullarray` where `data` has a corresponding null valu
 See also: [`fits_read_pix`](@ref)
 """
 function fits_read_pixnull(f::FITSFile, data::StridedArray, nullarray::Array{UInt8})
-    fits_read_pixnull(f, ones(Int64, fits_get_img_dim(f)), length(data), data, nullarray)
+    fits_read_pixnull(f, onest(Int64, fits_get_img_dim(f)), length(data), data, nullarray)
 end
 
 """


### PR DESCRIPTION
This was changed in v1.7.1 as using a `Vector` instead of a `Tuple` improves type-stability, but since there is a function barrier, the instability does not appear to matter for performance. Using a `Tuple` leads to zero allocations, even though this introduces a type-instability.

```julia
julia> @btime fits_read_pix($f, $A); # vector
  147.441 ns (2 allocations: 80 bytes)

julia> @btime fits_read_pix($f, $A); # tuple
  139.501 ns (0 allocations: 0 bytes)
```

Opening this PR to discuss what people prefer.

Alternately, we may define a custom `Ones` vector implementation analogous to `FillArrays`, which would be type-stable as well as allocation-free.